### PR TITLE
Updated game text style

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -190,7 +190,7 @@ var TitleScreen = function TitleScreen(title, subtitle, callback) {
   };
 
   this.draw = function (ctx) {
-    ctx.fillStyle = "#FFFFFF";
+    ctx.fillStyle = "#00FF00";
 
     ctx.font = "bold 40px bangers";
     var measure = ctx.measureText(title);
@@ -480,7 +480,7 @@ var GamePoints = function () {
   this.draw = function (ctx) {
     ctx.save();
     ctx.font = "bold 18px arial";
-    ctx.fillStyle = "#FFFFFF";
+    ctx.fillStyle = "#00FF00";
 
     var txt = "" + Game.points;
     var i = pointsLength - txt.length,

--- a/game.js
+++ b/game.js
@@ -125,7 +125,7 @@ var Starfield = function (speed, opacity, numStars, clear) {
   // If the clear option is set,
   // make the background black instead of transparent
   if (clear) {
-    starCtx.fillStyle = "#000";
+    starCtx.fillStyle = "#0F0";
     starCtx.fillRect(0, 0, stars.width, stars.height);
   }
 


### PR DESCRIPTION
This pull request updates the color scheme in the game's UI elements to use green tones instead of white and black. The changes affect the title screen, game points display, and starfield background.

### UI Color Updates:

* [`engine.js`](diffhunk://#diff-6683a049b66cf3099bf0abddb315e641eabc4fe512082e541a1dfdca072c1445L193-R193): Changed the `TitleScreen` text color from white (`#FFFFFF`) to green (`#00FF00`).
* [`engine.js`](diffhunk://#diff-6683a049b66cf3099bf0abddb315e641eabc4fe512082e541a1dfdca072c1445L483-R483): Updated the `GamePoints` text color from white (`#FFFFFF`) to green (`#00FF00`).
* [`game.js`](diffhunk://#diff-90096df085a22d3734b4eaf6ea3ec3395e0fb2c6418a262d84c1c567d10f48bbL128-R128): Modified the `Starfield` background color from black (`#000`) to a green shade (`#0F0`) when the `clear` option is set.